### PR TITLE
Added CMake project file and GitHub Action

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -1,0 +1,41 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+jobs:
+    build:
+        name: Build ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+          fail-fast: false
+          matrix:
+              os: [ubuntu-latest, macos-latest]
+        steps:
+          - name: Git Checkout
+            uses: actions/checkout@v2
+            with:
+              fetch-depth: 0
+          - name: Create Build Directory
+            run: |
+              mkdir build
+              cd build
+              mkdir release
+              mkdir debug
+          - name: Configure
+            run: |
+              cd build/release
+              cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=RELEASE ../../
+              cd ../debug
+              cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=DEBUG ../../
+          - name: Build
+            run: |
+              cd build/release
+              cmake --build .
+              cd ../debug
+              cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.14)
+project(pallab123  LANGUAGES CXX)
+add_executable(pallab123 ReadData.cpp)


### PR DESCRIPTION
After merge you can use the "Actions" tab of Github to test the program compilong on both Ubuntu and MacOS (couldn't add windows because you include a POSIX header)